### PR TITLE
Feature: full-body avatar

### DIFF
--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -6,6 +6,7 @@ AFRAME.registerComponent("avatar-animation", {
   animations: new Map(),
   accelerationFront: 0,
   accelerationRight: 0,
+  boost: false,
 
   update() {
     this.animations.clear();
@@ -17,6 +18,8 @@ AFRAME.registerComponent("avatar-animation", {
       this.animations.get(animation.name).play();
       this.animations.get(animation.name).setEffectiveWeight(0);
     });
+
+    console.log(this.animations);
 
     this.animations.get("Idle")?.setEffectiveWeight(1);
   },
@@ -30,10 +33,12 @@ AFRAME.registerComponent("avatar-animation", {
       return;
     }
 
-    this.animations.get("Walking")?.setEffectiveWeight(this.accelerationFront);
-    this.animations.get("WalkingBackwards")?.setEffectiveWeight(-this.accelerationFront);
-    this.animations.get("LeftStrafeWalk")?.setEffectiveWeight(-this.accelerationRight);
-    this.animations.get("RightStrafeWalk")?.setEffectiveWeight(this.accelerationRight);
+    this.animations.get(this.boost ? "Running" : "Walking")?.setEffectiveWeight(this.accelerationFront);
+    this.animations
+      .get(this.boost ? "RunningBackward" : "WalkingBackwards")
+      ?.setEffectiveWeight(-this.accelerationFront);
+    this.animations.get(this.boost ? "LeftStrafe" : "LeftStrafeWalk")?.setEffectiveWeight(-this.accelerationRight);
+    this.animations.get(this.boost ? "RightStrafe" : "RightStrafeWalk")?.setEffectiveWeight(this.accelerationRight);
   },
 
   _isStopped() {

--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -1,0 +1,25 @@
+AFRAME.registerComponent("avatar-animation", {
+  clock: new THREE.Clock(),
+  /**
+   * @type {Map<string, THREE.AnimationClip>}
+   */
+  animations: new Map(),
+
+  update() {
+    this.animations.clear();
+
+    this.mixer = new THREE.AnimationMixer(this.el.components["ik-controller"].avatar);
+
+    this.el.object3D.parent.animations.forEach(animation => {
+      this.animations.set(animation.name, this.mixer.clipAction(animation));
+      this.animations.get(animation.name).play();
+      this.animations.get(animation.name).setEffectiveWeight(0);
+    });
+
+    this.animations.get("Idle")?.setEffectiveWeight(1);
+  },
+
+  tick() {
+    this.mixer.update(this.clock.getDelta());
+  }
+});

--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -4,6 +4,8 @@ AFRAME.registerComponent("avatar-animation", {
    * @type {Map<string, THREE.AnimationClip>}
    */
   animations: new Map(),
+  accelerationFront: 0,
+  accelerationRight: 0,
 
   update() {
     this.animations.clear();
@@ -21,5 +23,20 @@ AFRAME.registerComponent("avatar-animation", {
 
   tick() {
     this.mixer.update(this.clock.getDelta());
+
+    if (this._isStopped()) {
+      this.animations.forEach(animation => animation.setEffectiveWeight(0));
+      this.animations.get("Idle")?.setEffectiveWeight(1);
+      return;
+    }
+
+    this.animations.get("Walking")?.setEffectiveWeight(this.accelerationFront);
+    this.animations.get("WalkingBackwards")?.setEffectiveWeight(-this.accelerationFront);
+    this.animations.get("LeftStrafeWalk")?.setEffectiveWeight(-this.accelerationRight);
+    this.animations.get("RightStrafeWalk")?.setEffectiveWeight(this.accelerationRight);
+  },
+
+  _isStopped() {
+    return this.accelerationFront === 0 && this.accelerationRight === 0;
   }
 });

--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -94,6 +94,8 @@ AFRAME.registerComponent("avatar-animation", {
       return;
     }
 
+    this._resetIdle();
+
     if (this.boost) {
       this._resetWalking();
       this._running();
@@ -120,6 +122,10 @@ AFRAME.registerComponent("avatar-animation", {
   _idle() {
     this._reset(ANIMATIONS.IDLE);
     this.animations.get(ANIMATIONS.IDLE)?.setEffectiveWeight(1);
+  },
+
+  _resetIdle() {
+    this.animations.get(ANIMATIONS.IDLE)?.setEffectiveWeight(0);
   },
 
   /**

--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -46,12 +46,35 @@ AFRAME.registerComponent("avatar-animation", {
       return;
     }
 
-    this.animations.get(this.boost ? "Running" : "Walking")?.setEffectiveWeight(this.accelerationFront);
-    this.animations
-      .get(this.boost ? "RunningBackward" : "WalkingBackwards")
-      ?.setEffectiveWeight(-this.accelerationFront);
-    this.animations.get(this.boost ? "LeftStrafe" : "LeftStrafeWalk")?.setEffectiveWeight(-this.accelerationRight);
-    this.animations.get(this.boost ? "RightStrafe" : "RightStrafeWalk")?.setEffectiveWeight(this.accelerationRight);
+    if (this.boost) {
+      this._removeWalkingAnimation();
+
+      this.animations.get("Running")?.setEffectiveWeight(this.accelerationFront);
+      this.animations.get("RunningBackward")?.setEffectiveWeight(-this.accelerationFront);
+      this.animations.get("LeftStrafe")?.setEffectiveWeight(-this.accelerationRight);
+      this.animations.get("RightStrafe")?.setEffectiveWeight(this.accelerationRight);
+    } else {
+      this._removeRunningAnimation();
+
+      this.animations.get("Walking")?.setEffectiveWeight(this.accelerationFront);
+      this.animations.get("WalkingBackwards")?.setEffectiveWeight(-this.accelerationFront);
+      this.animations.get("LeftStrafeWalk")?.setEffectiveWeight(-this.accelerationRight);
+      this.animations.get("RightStrafeWalk")?.setEffectiveWeight(this.accelerationRight);
+    }
+  },
+
+  _removeWalkingAnimation() {
+    this.animations.get("Walking")?.setEffectiveWeight(0);
+    this.animations.get("WalkingBackwards")?.setEffectiveWeight(0);
+    this.animations.get("LeftStrafeWalk")?.setEffectiveWeight(0);
+    this.animations.get("RightStrafeWalk")?.setEffectiveWeight(0);
+  },
+
+  _removeRunningAnimation() {
+    this.animations.get("Running")?.setEffectiveWeight(0);
+    this.animations.get("RunningBackward")?.setEffectiveWeight(0);
+    this.animations.get("LeftStrafe")?.setEffectiveWeight(0);
+    this.animations.get("RightStrafe")?.setEffectiveWeight(0);
   },
 
   _isStopped() {

--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -35,32 +35,23 @@ AFRAME.registerComponent("avatar-animation", {
     this.mixer.update(this.clock.getDelta());
 
     if (this.fly) {
-      this.animations.forEach(animation => animation.setEffectiveWeight(0));
-      this.animations.get("Flying")?.setEffectiveWeight(1);
+      this._flying();
       return;
     }
 
     if (this._isStopped()) {
-      this.animations.forEach(animation => animation.setEffectiveWeight(0));
-      this.animations.get("Idle")?.setEffectiveWeight(1);
+      this._idle();
       return;
     }
 
     if (this.boost) {
       this._removeWalkingAnimation();
-
-      this.animations.get("Running")?.setEffectiveWeight(this.accelerationFront);
-      this.animations.get("RunningBackward")?.setEffectiveWeight(-this.accelerationFront);
-      this.animations.get("LeftStrafe")?.setEffectiveWeight(-this.accelerationRight);
-      this.animations.get("RightStrafe")?.setEffectiveWeight(this.accelerationRight);
-    } else {
-      this._removeRunningAnimation();
-
-      this.animations.get("Walking")?.setEffectiveWeight(this.accelerationFront);
-      this.animations.get("WalkingBackwards")?.setEffectiveWeight(-this.accelerationFront);
-      this.animations.get("LeftStrafeWalk")?.setEffectiveWeight(-this.accelerationRight);
-      this.animations.get("RightStrafeWalk")?.setEffectiveWeight(this.accelerationRight);
+      this._running();
+      return;
     }
+
+    this._removeRunningAnimation();
+    this._walking();
   },
 
   _removeWalkingAnimation() {
@@ -75,6 +66,30 @@ AFRAME.registerComponent("avatar-animation", {
     this.animations.get("RunningBackward")?.setEffectiveWeight(0);
     this.animations.get("LeftStrafe")?.setEffectiveWeight(0);
     this.animations.get("RightStrafe")?.setEffectiveWeight(0);
+  },
+
+  _flying() {
+    this.animations.forEach(animation => animation.setEffectiveWeight(0));
+    this.animations.get("Flying")?.setEffectiveWeight(1);
+  },
+
+  _idle() {
+    this.animations.forEach(animation => animation.setEffectiveWeight(0));
+    this.animations.get("Idle")?.setEffectiveWeight(1);
+  },
+
+  _running() {
+    this.animations.get("Running")?.setEffectiveWeight(this.accelerationFront);
+    this.animations.get("RunningBackward")?.setEffectiveWeight(-this.accelerationFront);
+    this.animations.get("LeftStrafe")?.setEffectiveWeight(-this.accelerationRight);
+    this.animations.get("RightStrafe")?.setEffectiveWeight(this.accelerationRight);
+  },
+
+  _walking() {
+    this.animations.get("Walking")?.setEffectiveWeight(this.accelerationFront);
+    this.animations.get("WalkingBackwards")?.setEffectiveWeight(-this.accelerationFront);
+    this.animations.get("LeftStrafeWalk")?.setEffectiveWeight(-this.accelerationRight);
+    this.animations.get("RightStrafeWalk")?.setEffectiveWeight(this.accelerationRight);
   },
 
   _isStopped() {

--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -113,17 +113,26 @@ AFRAME.registerComponent("avatar-animation", {
   },
 
   _flying() {
-    this._reset();
+    this._reset(ANIMATIONS.FLYING);
     this.animations.get(ANIMATIONS.FLYING)?.setEffectiveWeight(1);
   },
 
   _idle() {
-    this._reset();
+    this._reset(ANIMATIONS.IDLE);
     this.animations.get(ANIMATIONS.IDLE)?.setEffectiveWeight(1);
   },
 
-  _reset() {
-    this.animations.forEach(animation => animation.setEffectiveWeight(0));
+  /**
+   * @param {string[]} ignore - list of ignore to reset animation
+   */
+  _reset(...ignore) {
+    this.animations.forEach(animation => {
+      if (ignore.includes(animation.name)) {
+        return;
+      }
+
+      animation.setEffectiveWeight(0);
+    });
   },
 
   _running() {

--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -7,6 +7,15 @@ AFRAME.registerComponent("avatar-animation", {
   accelerationFront: 0,
   accelerationRight: 0,
   boost: false,
+  fly: false,
+
+  set(key, value) {
+    this[key] = value;
+  },
+
+  get(key) {
+    return this[key];
+  },
 
   update() {
     this.animations.clear();
@@ -19,13 +28,17 @@ AFRAME.registerComponent("avatar-animation", {
       this.animations.get(animation.name).setEffectiveWeight(0);
     });
 
-    console.log(this.animations);
-
     this.animations.get("Idle")?.setEffectiveWeight(1);
   },
 
   tick() {
     this.mixer.update(this.clock.getDelta());
+
+    if (this.fly) {
+      this.animations.forEach(animation => animation.setEffectiveWeight(0));
+      this.animations.get("Flying")?.setEffectiveWeight(1);
+      return;
+    }
 
     if (this._isStopped()) {
       this.animations.forEach(animation => animation.setEffectiveWeight(0));

--- a/src/components/avatar-animation.js
+++ b/src/components/avatar-animation.js
@@ -1,3 +1,53 @@
+/**
+ * @typedef {"Idle"} IDLE
+ * @typedef {"Walking"} WALKING
+ * @typedef {"WalkingBackwards"} WALKING_BACKWARD
+ * @typedef {"LeftStrafeWalk"} WALKING_LEFT
+ * @typedef {"RightStrafeWalk"} WALKING_RIGHT
+ * @typedef {"Running"} RUNNING
+ * @typedef {"RunningBackward"} RUNNING_BACKWARD
+ * @typedef {"LeftStrafe"} RUNNING_LEFT
+ * @typedef {"RightStrafe"} RUNNING_RIGHT
+ * @typedef {"Flying"} FLYING
+ *
+ * @type {{
+ *   IDLE: IDLE;
+ *   WALKING: WALKING;
+ *   WALKING_BACKWARD: WALKING_BACKWARD;
+ *   WALKING_LEFT: WALKING_LEFT;
+ *   WALKING_RIGHT: WALKING_RIGHT;
+ *   RUNNING: RUNNING;
+ *   RUNNING_BACKWARD: RUNNING_BACKWARD;
+ *   RUNNING_LEFT: RUNNING_LEFT;
+ *   RUNNING_RIGHT: RUNNING_RIGHT;
+ *   FLYING: FLYING;
+ * }}
+ */
+const ANIMATIONS = {
+  IDLE: "Idle",
+  WALKING: "Walking",
+  WALKING_BACKWARD: "WalkingBackwards",
+  WALKING_LEFT: "LeftStrafeWalk",
+  WALKING_RIGHT: "RightStrafeWalk",
+  RUNNING: "Running",
+  RUNNING_BACKWARD: "RunningBackward",
+  RUNNING_LEFT: "LeftStrafe",
+  RUNNING_RIGHT: "RightStrafe",
+  FLYING: "Flying"
+};
+const WALKING_ANIMATIONS = [
+  ANIMATIONS.WALKING,
+  ANIMATIONS.WALKING_BACKWARD,
+  ANIMATIONS.WALKING_LEFT,
+  ANIMATIONS.WALKING_RIGHT
+];
+const RUNNING_ANIMATIONS = [
+  ANIMATIONS.RUNNING,
+  ANIMATIONS.RUNNING_BACKWARD,
+  ANIMATIONS.RUNNING_LEFT,
+  ANIMATIONS.RUNNING_RIGHT
+];
+
 AFRAME.registerComponent("avatar-animation", {
   clock: new THREE.Clock(),
   /**
@@ -28,7 +78,7 @@ AFRAME.registerComponent("avatar-animation", {
       this.animations.get(animation.name).setEffectiveWeight(0);
     });
 
-    this.animations.get("Idle")?.setEffectiveWeight(1);
+    this.animations.get(ANIMATIONS.IDLE)?.setEffectiveWeight(1);
   },
 
   tick() {
@@ -45,51 +95,49 @@ AFRAME.registerComponent("avatar-animation", {
     }
 
     if (this.boost) {
-      this._removeWalkingAnimation();
+      this._resetWalking();
       this._running();
       return;
     }
 
-    this._removeRunningAnimation();
+    this._resetRunning();
     this._walking();
   },
 
-  _removeWalkingAnimation() {
-    this.animations.get("Walking")?.setEffectiveWeight(0);
-    this.animations.get("WalkingBackwards")?.setEffectiveWeight(0);
-    this.animations.get("LeftStrafeWalk")?.setEffectiveWeight(0);
-    this.animations.get("RightStrafeWalk")?.setEffectiveWeight(0);
+  _resetWalking() {
+    WALKING_ANIMATIONS.forEach(name => this.animations.get(name)?.setEffectiveWeight(0));
   },
 
-  _removeRunningAnimation() {
-    this.animations.get("Running")?.setEffectiveWeight(0);
-    this.animations.get("RunningBackward")?.setEffectiveWeight(0);
-    this.animations.get("LeftStrafe")?.setEffectiveWeight(0);
-    this.animations.get("RightStrafe")?.setEffectiveWeight(0);
+  _resetRunning() {
+    RUNNING_ANIMATIONS.forEach(name => this.animations.get(name)?.setEffectiveWeight(0));
   },
 
   _flying() {
-    this.animations.forEach(animation => animation.setEffectiveWeight(0));
-    this.animations.get("Flying")?.setEffectiveWeight(1);
+    this._reset();
+    this.animations.get(ANIMATIONS.FLYING)?.setEffectiveWeight(1);
   },
 
   _idle() {
+    this._reset();
+    this.animations.get(ANIMATIONS.IDLE)?.setEffectiveWeight(1);
+  },
+
+  _reset() {
     this.animations.forEach(animation => animation.setEffectiveWeight(0));
-    this.animations.get("Idle")?.setEffectiveWeight(1);
   },
 
   _running() {
-    this.animations.get("Running")?.setEffectiveWeight(this.accelerationFront);
-    this.animations.get("RunningBackward")?.setEffectiveWeight(-this.accelerationFront);
-    this.animations.get("LeftStrafe")?.setEffectiveWeight(-this.accelerationRight);
-    this.animations.get("RightStrafe")?.setEffectiveWeight(this.accelerationRight);
+    this.animations.get(ANIMATIONS.RUNNING)?.setEffectiveWeight(this.accelerationFront);
+    this.animations.get(ANIMATIONS.RUNNING_BACKWARD)?.setEffectiveWeight(-this.accelerationFront);
+    this.animations.get(ANIMATIONS.RUNNING_LEFT)?.setEffectiveWeight(-this.accelerationRight);
+    this.animations.get(ANIMATIONS.RUNNING_RIGHT)?.setEffectiveWeight(this.accelerationRight);
   },
 
   _walking() {
-    this.animations.get("Walking")?.setEffectiveWeight(this.accelerationFront);
-    this.animations.get("WalkingBackwards")?.setEffectiveWeight(-this.accelerationFront);
-    this.animations.get("LeftStrafeWalk")?.setEffectiveWeight(-this.accelerationRight);
-    this.animations.get("RightStrafeWalk")?.setEffectiveWeight(this.accelerationRight);
+    this.animations.get(ANIMATIONS.WALKING)?.setEffectiveWeight(this.accelerationFront);
+    this.animations.get(ANIMATIONS.WALKING_BACKWARD)?.setEffectiveWeight(-this.accelerationFront);
+    this.animations.get(ANIMATIONS.WALKING_LEFT)?.setEffectiveWeight(-this.accelerationRight);
+    this.animations.get(ANIMATIONS.WALKING_RIGHT)?.setEffectiveWeight(this.accelerationRight);
   },
 
   _isStopped() {

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -212,8 +212,24 @@ AFRAME.registerComponent("ik-controller", {
       this.chest = this.el.object3D.getObjectByName(this.data.chest);
     }
 
+    const avatar = this.el.closest(".model");
+    if (this._hasFoot()) {
+      avatar.setAttribute("position", new THREE.Vector3(0, -1.2, 0));
+    } else {
+      avatar.removeAttribute("position");
+    }
+
+    this._hands.forEach(hand => {
+      if (this._isNoControllerAndNoArmAvatar(hand)) {
+        this._hideHand(hand);
+      }
+    });
+
     // Set middleEye's position to be right in the middle of the left and right eyes.
-    this.middleEyePosition.addVectors(this.leftEye.position, this.rightEye.position);
+    this.middleEyePosition.addVectors(
+      this.leftEye?.position || new THREE.Vector3(0, 1.6, 0),
+      this.rightEye?.position || new THREE.Vector3(0, 1.6, 0)
+    );
     this.middleEyePosition.divideScalar(2);
     this.middleEyeMatrix.makeTranslation(this.middleEyePosition.x, this.middleEyePosition.y, this.middleEyePosition.z);
     this.invMiddleEyeToHead = this.middleEyeMatrix.copy(this.middleEyeMatrix).invert();
@@ -447,5 +463,30 @@ AFRAME.registerComponent("ik-controller", {
    */
   _existsControllerAndHand(hand) {
     return this._getController(hand).object3D.visible && this._getHand(hand);
+  },
+
+  /**
+   * @private
+   * @param {Hand} hand
+   * @returns {boolean}
+   */
+  _isNoControllerAndNoArmAvatar(hand) {
+    return !this.ikRoot[`${hand}Controller`].object3D.visible && !this[`${hand}Arm`];
+  },
+
+  /**
+   * @private
+   * @param {Hand} hand
+   */
+  _hideHand(hand) {
+    this[`${hand}Hand`]?.el.setAttribute("visible", false);
+  },
+
+  /**
+   * @private
+   * @returns {boolean}
+   */
+  _hasFoot() {
+    return this.leftFoot || this.rightFoot;
   }
 });

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -80,7 +80,17 @@ AFRAME.registerComponent("ik-controller", {
     head: { type: "string", default: "Head" },
     neck: { type: "string", default: "Neck" },
     leftHand: { type: "string", default: "LeftHand" },
+    leftForeArm: { type: "string", default: "LeftForeArm" },
+    leftArm: { type: "string", default: "LeftArm" },
     rightHand: { type: "string", default: "RightHand" },
+    rightForeArm: { type: "string", default: "RightForeArm" },
+    rightArm: { type: "string", default: "RightArm" },
+    leftFoot: { type: "string", default: "LeftFoot" },
+    leftLeg: { type: "string", default: "LeftLeg" },
+    leftUpLeg: { type: "string", default: "LeftUpLeg" },
+    rightFoot: { type: "string", default: "RightFoot" },
+    rightLeg: { type: "string", default: "RightLeg" },
+    rightUpLeg: { type: "string", default: "RightUpLeg" },
     chest: { type: "string", default: "Spine" },
     rotationSpeed: { default: 8 },
     maxLerpAngle: { default: 90 * THREE.MathUtils.DEG2RAD },
@@ -152,8 +162,48 @@ AFRAME.registerComponent("ik-controller", {
       this.leftHand = this.el.object3D.getObjectByName(this.data.leftHand);
     }
 
+    if (this.data.leftForeArm !== oldData.leftForeArm) {
+      this.leftForeArm = this.el.object3D.getObjectByName(this.data.leftForeArm);
+    }
+
+    if (this.data.leftArm !== oldData.leftArm) {
+      this.leftArm = this.el.object3D.getObjectByName(this.data.leftArm);
+    }
+
     if (this.data.rightHand !== oldData.rightHand) {
       this.rightHand = this.el.object3D.getObjectByName(this.data.rightHand);
+    }
+
+    if (this.data.rightForeArm !== oldData.rightForeArm) {
+      this.rightForeArm = this.el.object3D.getObjectByName(this.data.rightForeArm);
+    }
+
+    if (this.data.rightArm !== oldData.rightArm) {
+      this.rightArm = this.el.object3D.getObjectByName(this.data.rightArm);
+    }
+
+    if (this.data.leftFoot !== oldData.leftFoot) {
+      this.leftFoot = this.el.object3D.getObjectByName(this.data.leftFoot);
+    }
+
+    if (this.data.leftLeg !== oldData.leftLeg) {
+      this.leftLeg = this.el.object3D.getObjectByName(this.data.leftLeg);
+    }
+
+    if (this.data.leftUpLeg !== oldData.leftUpLeg) {
+      this.leftUpLeg = this.el.object3D.getObjectByName(this.data.leftUpLeg);
+    }
+    
+    if (this.data.rightFoot !== oldData.rightFoot) {
+      this.rightFoot = this.el.object3D.getObjectByName(this.data.rightFoot);
+    }
+
+    if (this.data.rightLeg !== oldData.rightLeg) {
+      this.rightLeg = this.el.object3D.getObjectByName(this.data.rightLeg);
+    }
+
+    if (this.data.rightUpLeg !== oldData.rightUpLeg) {
+      this.rightUpLeg = this.el.object3D.getObjectByName(this.data.rightUpLeg);
     }
 
     if (this.data.chest !== oldData.chest) {

--- a/src/components/name-tag.js
+++ b/src/components/name-tag.js
@@ -18,6 +18,8 @@ const NAMETAG_HEIGHT = 0.25;
 const NAMETAG_OFFSET = 0.2;
 const TYPING_ANIM_SPEED = 150;
 const DISPLAY_NAME_LENGTH = 18;
+const HUBS_AVATAR_ROOT = "AvatarRoot";
+const STANDARD_AVATAR_ROOT = "Armature";
 
 const ANIM_CONFIG = {
   duration: 400,
@@ -253,7 +255,7 @@ AFRAME.registerComponent("name-tag", {
     await nextTick();
     this.ikRoot = findAncestorWithComponent(this.el, "ik-root").object3D;
     this.neck = this.ikRoot.el.querySelector(".Neck").object3D;
-    this.audioAnalyzer = this.ikRoot.el.querySelector(".AvatarRoot").components["networked-audio-analyser"];
+    this.audioAnalyzer = this._getAudioAnalyzer();
 
     this.updateAvatarModelAABB();
     const tmpVector = new THREE.Vector3();
@@ -269,6 +271,21 @@ AFRAME.registerComponent("name-tag", {
     this.updateDisplayName();
     this.updateHandRaised();
     this.resizeNameTag();
+  },
+
+  /**
+   * @private
+   */
+  _getAudioAnalyzer() {
+    const selector = "." + this._isBasisHubsAvatar() ? HUBS_AVATAR_ROOT : STANDARD_AVATAR_ROOT;
+    return (this.audioAnalyzer = this.ikRoot.el.querySelector(selector).components["networked-audio-analyser"]);
+  },
+
+  /**
+   * @private
+   */
+  _isBasisHubsAvatar() {
+    return this.ikRoot.el.object3D.getObjectByName("AvatarRoot");
   },
 
   updateTheme() {

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -23,6 +23,16 @@ function ensureAvatarNodes(json) {
       extensions: { MOZ_hubs_components: { "scale-audio-feedback": "" } }
     });
     nodes.push({ name: "Neck", children: [nodes.length - 1] });
+    nodes.push({ name: "RightFoot", children: [nodes.length - 1] });
+    nodes.push({ name: "RightLeg", children: [nodes.length - 1] });
+    nodes.push({ name: "RightUpLeg", children: [nodes.length - 1] });
+    nodes.push({ name: "LeftFoot", children: [nodes.length - 1] });
+    nodes.push({ name: "LeftLeg", children: [nodes.length - 1] });
+    nodes.push({ name: "LeftUpLeg", children: [nodes.length - 1] });
+    nodes.push({ name: "RightForeArm", children: [nodes.length - 1] });
+    nodes.push({ name: "RightArm", children: [nodes.length - 1] });
+    nodes.push({ name: "LeftForeArm", children: [nodes.length - 1] });
+    nodes.push({ name: "LeftArm", children: [nodes.length - 1] });
     nodes.push({ name: "Spine", children: [nodes.length - 1] });
     nodes.push({ name: "Hips", children: [nodes.length - 1] });
     nodes.push({ name: "AvatarRoot", children: [nodes.length - 1] });

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -13,6 +13,7 @@ function ensureAvatarNodes(json) {
     // So, we need to construct a suitable hierarchy for avatar functionality to work.
     // We re-parent the original root node to the Head node and set the scene root to a new AvatarRoot.
 
+    // Note: If model's root name is 'Armature', the scene root is Armature. (This added with Full-body avatar feature)
     // Note: We assume that the first node in the primary scene is the one we care about.
     const originalRoot = json.scenes[json.scene].nodes[0];
     nodes.push({ name: "LeftEye", extensions: { MOZ_hubs_components: {} } });
@@ -36,6 +37,7 @@ function ensureAvatarNodes(json) {
     nodes.push({ name: "Spine", children: [nodes.length - 1] });
     nodes.push({ name: "Hips", children: [nodes.length - 1] });
     nodes.push({ name: "AvatarRoot", children: [nodes.length - 1] });
+    nodes.push({ name: "Armature", children: [nodes.length - 1] });
     json.scenes[json.scene].nodes[0] = nodes.length - 1;
   }
   return json;

--- a/src/hub.html
+++ b/src/hub.html
@@ -148,6 +148,15 @@
                             >
                             </a-entity>
                         </template>
+                        <template data-name="Armature">
+                            <a-entity
+                                ik-controller
+                                hand-pose__left
+                                hand-pose__right
+                                networked-audio-analyser
+                            >
+                            </a-entity>
+                        </template>
 
                         <template data-name="Spine">
                             <a-entity is-remote-hover-target personal-space-invader="radius: 0.2; useMaterial: true;" bone-visibility>
@@ -1095,6 +1104,16 @@
 
             <a-entity gltf-model-plus="inflate: true;" class="model">
                 <template data-name="AvatarRoot">
+                    <a-entity
+                        ik-controller="alwaysUpdate: true"
+                        disable-frustum-culling
+                        hand-pose__left
+                        hand-pose__right
+                        hand-pose-controller__left="networkedAvatar:#avatar-rig;eventSrc:#player-left-controller"
+                        hand-pose-controller__right="networkedAvatar:#avatar-rig;eventSrc:#player-right-controller"
+                    ></a-entity>
+                </template>
+                <template data-name="Armature">
                     <a-entity
                         ik-controller="alwaysUpdate: true"
                         disable-frustum-culling

--- a/src/hub.html
+++ b/src/hub.html
@@ -211,6 +211,20 @@
                         <template data-name="RightHand">
                             <a-entity personal-space-invader="radius: 0.1" bone-visibility="updateWhileInvisible: true;"></a-entity>
                         </template>
+
+                        <template data-name="LeftForeArm"><a-entity></a-entity></template>
+                        <template data-name="LeftArm"><a-entity></a-entity></template>
+
+                        <template data-name="RightForeArm"><a-entity></a-entity></template>
+                        <template data-name="RightArm"><a-entity></a-entity></template>
+
+                        <template data-name="LeftUpLeg"><a-entity></a-entity></template>
+                        <template data-name="LeftLeg"><a-entity></a-entity></template>
+                        <template data-name="LeftFoot"><a-entity></a-entity></template>
+
+                        <template data-name="RightUpLeg"><a-entity></a-entity></template>
+                        <template data-name="RightLeg"><a-entity></a-entity></template>
+                        <template data-name="RightFoot"><a-entity></a-entity></template>
                     </a-entity>
                 </a-entity>
             </template>
@@ -1105,6 +1119,19 @@
                     <a-entity bone-visibility="updateWhileInvisible: true;" hover-visuals="hand: right;"></a-entity>
                 </template>
 
+                <template data-name="LeftForeArm"><a-entity></a-entity></template>
+                <template data-name="LeftArm"><a-entity></a-entity></template>
+
+                <template data-name="RightForeArm"><a-entity></a-entity></template>
+                <template data-name="RightArm"><a-entity></a-entity></template>
+
+                <template data-name="LeftUpLeg"><a-entity></a-entity></template>
+                <template data-name="LeftLeg"><a-entity></a-entity></template>
+                <template data-name="LeftFoot"><a-entity></a-entity></template>
+
+                <template data-name="RightUpLeg"><a-entity></a-entity></template>
+                <template data-name="RightLeg"><a-entity></a-entity></template>
+                <template data-name="RightFoot"><a-entity></a-entity></template>
             </a-entity>
         </a-entity>
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -142,6 +142,7 @@
                         <template data-name="AvatarRoot">
                             <a-entity
                                 ik-controller
+                                avatar-animation
                                 hand-pose__left
                                 hand-pose__right
                                 networked-audio-analyser
@@ -151,6 +152,7 @@
                         <template data-name="Armature">
                             <a-entity
                                 ik-controller
+                                avatar-animation
                                 hand-pose__left
                                 hand-pose__right
                                 networked-audio-analyser
@@ -1106,6 +1108,7 @@
                 <template data-name="AvatarRoot">
                     <a-entity
                         ik-controller="alwaysUpdate: true"
+                        avatar-animation
                         disable-frustum-culling
                         hand-pose__left
                         hand-pose__right
@@ -1116,6 +1119,7 @@
                 <template data-name="Armature">
                     <a-entity
                         ik-controller="alwaysUpdate: true"
+                        avatar-animation
                         disable-frustum-culling
                         hand-pose__left
                         hand-pose__right

--- a/src/hub.js
+++ b/src/hub.js
@@ -72,6 +72,7 @@ import "./components/emoji";
 import "./components/emoji-hud";
 import "./components/virtual-gamepad-controls";
 import "./components/ik-controller";
+import "./components/avatar-animation";
 import "./components/hand-controls2";
 import "./components/hoverable-visuals";
 import "./components/hover-visuals";

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -207,6 +207,7 @@ AFRAME.registerSystem("userinput", {
       generation: 0,
       values: {},
       generations: {},
+      animation: undefined,
       get: function(path) {
         if (this.generations[path] !== this.generation) return undefined;
         return this.values[path];
@@ -215,14 +216,22 @@ AFRAME.registerSystem("userinput", {
         this.values[path] = value;
         this.generations[path] = this.generation;
 
-        const isBoostChanged = path === paths.actions.boost && value !== undefined;
-        if (!isBoostChanged) {
+        if (!this.animation) {
+          this.animation = document.querySelector("[avatar-animation]")?.components?.["avatar-animation"];
+        }
+
+        if (!this.animation) {
           return;
         }
 
-        const animation = document.querySelector("[avatar-animation]")?.components?.["avatar-animation"];
-        if (animation) {
-          animation.boost = value;
+        const isBoostChanged = path === paths.actions.boost && value !== undefined;
+        if (isBoostChanged) {
+          this.animation?.set("boost", value);
+        }
+
+        const isToggleFly = path === paths.actions.toggleFly && value === true;
+        if (isToggleFly) {
+          this.animation?.set("fly", !this.animation?.get("fly"));
         }
       },
       setVector2: function(path, right, front) {

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -214,6 +214,16 @@ AFRAME.registerSystem("userinput", {
       setValueType: function(path, value) {
         this.values[path] = value;
         this.generations[path] = this.generation;
+
+        const isBoostChanged = path === paths.actions.boost && value !== undefined;
+        if (!isBoostChanged) {
+          return;
+        }
+
+        const animation = document.querySelector("[avatar-animation]")?.components?.["avatar-animation"];
+        if (animation) {
+          animation.boost = value;
+        }
       },
       setVector2: function(path, right, front) {
         const value = this.values[path] || [];

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -215,12 +215,23 @@ AFRAME.registerSystem("userinput", {
         this.values[path] = value;
         this.generations[path] = this.generation;
       },
-      setVector2: function(path, a, b) {
+      setVector2: function(path, right, front) {
         const value = this.values[path] || [];
-        value[0] = a;
-        value[1] = b;
+        value[0] = right;
+        value[1] = front;
         this.values[path] = value;
         this.generations[path] = this.generation;
+
+        const isCharacterMove = path === "/actions/characterAcceleration";
+        if (!isCharacterMove) {
+          return;
+        }
+
+        const animation = document.querySelector("[avatar-animation]")?.components?.["avatar-animation"];
+        if (animation) {
+          animation.accelerationFront = front;
+          animation.accelerationRight = right;
+        }
       },
       setPose: function(path, pose) {
         this.setValueType(path, pose);

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -220,10 +220,6 @@ AFRAME.registerSystem("userinput", {
           this.animation = document.querySelector("[avatar-animation]")?.components?.["avatar-animation"];
         }
 
-        if (!this.animation) {
-          return;
-        }
-
         const isBoostChanged = path === paths.actions.boost && value !== undefined;
         if (isBoostChanged) {
           this.animation?.set("boost", value);
@@ -246,11 +242,12 @@ AFRAME.registerSystem("userinput", {
           return;
         }
 
-        const animation = document.querySelector("[avatar-animation]")?.components?.["avatar-animation"];
-        if (animation) {
-          animation.accelerationFront = front;
-          animation.accelerationRight = right;
+        if (!this.animation) {
+          this.animation = document.querySelector("[avatar-animation]")?.components?.["avatar-animation"];
         }
+
+        this.animation?.set("accelerationFront", front);
+        this.animation?.set("accelerationRight", right);
       },
       setPose: function(path, pose) {
         this.setValueType(path, pose);

--- a/src/utils/avatar-utils.js
+++ b/src/utils/avatar-utils.js
@@ -61,7 +61,7 @@ export async function getAvatarThumbnailUrl(avatarId) {
 // arbitrary models with some sort of functionality. This provides a fallback
 export const MAT_NAME = "Bot_PBS";
 export function ensureAvatarMaterial(gltf) {
-  if (gltf.materials.find(m => m.name === MAT_NAME)) return gltf;
+  if (gltf.materials?.find(m => m.name === MAT_NAME)) return gltf;
 
   function materialForMesh(mesh) {
     if (!mesh.primitives) return;


### PR DESCRIPTION
# Doing

- 팔다리 추가
- AvatarRoot와 Armature 와 호환이 되도록 조치
- 팔이 있으면 컨트롤러가 없어도 손이 보임
- 팔이 없으면 컨트롤러가 없으면 손이 안보임
- `avatar-animation` AFRAME 컴포넌트 작성
    - 아바타가 걸어다니는 부분의 구현을 위한 AFRAME 컴포넌트
    - 걸어다니는 애니메이션 적용
    - 뛰어다니는 애니메이션 적용
    - 날아다니는 애니메이션 적용
- `userinput` 이 들어오면 `avatar-animation` 컴포넌트에 움직임 정보 전달
- 유저가 움직일 때 걸어다니는 애니메이션이 들어가도록 처리

# Why

- 기존의 허브 아바타가 AvatarRoot 라는 용어를 쓰고 있음
- 다른 대부분의 메타버스 플랫폼의 아바타가 Armature 라는 용어를 씀. 거의 국룰인듯
- 기존 아바타 처럼 팔이 없으면 손도 안보여야 맞는 듯 해서 기존처럼 컨트롤러 없으면 안보이게 처리함

# TODO

- 전신 아바타가 컨트롤러가 있을 때 손목부터 손만 고무고무 할거라서 그거 처리해야 함